### PR TITLE
Lägg till config via env-variabler

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,11 @@ The GUI will then be available at http://localhost:5002.
 The environment variable `GUNTHY_URL` can be set in `docker-compose.yml` to point
 to an alternative download link.
 
+Two further environment variables control the configuration written to
+`config.json` next to `gui-linux`:
+
+- `CONFIG_API_URL` sätter API-URL:en (standard `http://iptogb:port`)
+- `CONFIG_PORT` sätter portnumret (standard `5002`)
+
 The container installs `xvfb` and `xauth` and runs the GUI via `xvfb-run` so it
 works even without a graphical interface.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
       - "5002:5002"
     volumes:
       - gunthy-data:/home/gunthy
+    environment:
+      # Styr API-URL och port för config.json
+      #CONFIG_API_URL: http://iptogb:port
+      #CONFIG_PORT: 5002
     restart: unless-stopped
 
 volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
 set -e
-# Run the GUI in a headless X window
+
+# Skapa konfigurationsfil bredvid gui-linux
+CONFIG_FILE="$APP_HOME/config.json"
+API_URL="${CONFIG_API_URL:-http://iptogb:port}"
+GUI_PORT="${CONFIG_PORT:-5002}"
+
+cat > "$CONFIG_FILE" <<EOF
+{
+  "api_url": "$API_URL",
+  "port": $GUI_PORT
+}
+EOF
+
+# Kör GUI:t i ett huvudlöst X-fönster
 exec xvfb-run --auto-servernum --server-num=1 "$APP_HOME/gui-linux" "$@"


### PR DESCRIPTION
## Sammanfattning
- skapa `config.json` automatiskt i `entrypoint.sh`
- nya miljövariabler `CONFIG_API_URL` och `CONFIG_PORT`
- uppdatera `README.md`
- kommenterad `environment`-sektion i `docker-compose.yml`

## Testresultat
- `bash -n entrypoint.sh`
- `docker-compose config` _(misslyckades: `command not found`)_

------
https://chatgpt.com/codex/tasks/task_e_68626d42e040832aad7739c4376482fa