### PR TITLE
Expose GUI logs and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ Two further environment variables control the configuration written to
 
 The container installs `xvfb` and `xauth` and runs the GUI via `xvfb-run` so it
 works even without a graphical interface.
+
+## Logs
+
+All GUI output is saved to `gui.log` under `/opt/gunthy` inside the container and
+is also printed to STDOUT. View it with:
+
+```bash
+docker compose logs -f gunthy
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,4 @@ cat > "$CONFIG_FILE" <<EOF
 EOF
 
 # Kör GUI:t i ett huvudlöst X-fönster
-exec xvfb-run --auto-servernum --server-num=1 "$APP_HOME/gui-linux" "$@"
+exec xvfb-run --auto-servernum --server-num=1 "$APP_HOME/gui-linux" "$@" 2>&1 | tee -a "$APP_HOME/gui.log"


### PR DESCRIPTION
## Summary
- capture GUI output to `gui.log` using `tee`
- document where the log file lives
- show how to inspect logs via `docker compose`

## Testing
- `shellcheck entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862717f8608832ab3888b5624760386