### PR TITLE
Improve GUI entrypoint for robust logging

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -o pipefail
 
 # Skapa konfigurationsfil bredvid gui-linux
 CONFIG_FILE="$APP_HOME/config.json"
@@ -14,4 +15,5 @@ cat > "$CONFIG_FILE" <<EOF
 EOF
 
 # Kör GUI:t i ett huvudlöst X-fönster
-exec xvfb-run --auto-servernum --server-num=1 "$APP_HOME/gui-linux" "$@" 2>&1 | tee -a "$APP_HOME/gui.log"
+exec > >(tee -a "$APP_HOME/gui.log") 2>&1
+exec xvfb-run --auto-servernum --server-num=1 "$APP_HOME/gui-linux" "$@"


### PR DESCRIPTION
## Summary
- keep pipe failures from being ignored
- ensure logging tee doesn't become PID 1 by redirecting to process substitution

## Testing
- `shellcheck entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_686274b393b4832a8d907b1aa3b31d90