### PR TITLE
Lägg till stack.env och info om Portainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ is also printed to STDOUT. View it with:
 ```bash
 docker compose logs -f gunthy
 ```
+
+## Portainer
+
+Vid deployment via Portainer och valet **Repository** måste filen `stack.env`
+ligga i repots rot. Filen innehåller standardvariabler och kan redigeras
+direkt i Portainer eller med valfri texteditor innan deployment.

--- a/stack.env
+++ b/stack.env
@@ -1,0 +1,3 @@
+CONFIG_API_URL=http://iptogb:port
+CONFIG_PORT=5002
+GUNTHY_URL=


### PR DESCRIPTION
## Sammanfattning
- lägg till `stack.env` med defaultvärden för Gunbot GUI
- uppdatera `README.md` med instruktion för Portainer

## Testing
- `docker-compose config` *(misslyckades: command not found)*
- `docker compose config` *(misslyckades: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686275a5ab68832aa614ce26ca690403