### PR TITLE
Translate README and entrypoint comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ to an alternative download link.
 Two further environment variables control the configuration written to
 `config.json` next to `gui-linux`:
 
-- `CONFIG_API_URL` sätter API-URL:en (standard `http://iptogb:port`)
-- `CONFIG_PORT` sätter portnumret (standard `5002`)
+- `CONFIG_API_URL` sets the API URL (defaults to `http://iptogb:port`)
+- `CONFIG_PORT` sets the port number (defaults to `5002`)
+
+The entrypoint script rewrites `config.json` at startup using these values.
 
 The container installs `xvfb` and `xauth` and runs the GUI via `xvfb-run` so it
 works even without a graphical interface.
@@ -35,6 +37,6 @@ docker compose logs -f gunthy
 
 ## Portainer
 
-Vid deployment via Portainer och valet **Repository** måste filen `stack.env`
-ligga i repots rot. Filen innehåller standardvariabler och kan redigeras
-direkt i Portainer eller med valfri texteditor innan deployment.
+When deploying via Portainer with the **Repository** option, the `stack.env` file
+must reside in the repository root. The file contains default variables and can
+be edited directly in Portainer or with any text editor before deployment.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 set -o pipefail
 
-# Skapa konfigurationsfil bredvid gui-linux
+# Create configuration file next to gui-linux
 CONFIG_FILE="$APP_HOME/config.json"
 API_URL="${CONFIG_API_URL:-http://iptogb:port}"
 GUI_PORT="${CONFIG_PORT:-5002}"
@@ -14,6 +14,6 @@ cat > "$CONFIG_FILE" <<EOF
 }
 EOF
 
-# Kör GUI:t i ett huvudlöst X-fönster
+# Run the GUI in a headless X window
 exec > >(tee -a "$APP_HOME/gui.log") 2>&1
 exec xvfb-run --auto-servernum --server-num=1 "$APP_HOME/gui-linux" "$@"


### PR DESCRIPTION
## Summary
- translate Swedish text in README
- mention startup rewrite of `config.json`
- translate Portainer paragraph
- update comments in `entrypoint.sh`

## Testing
- `bash -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68627aa15458832ab96104ad12894c2c