### PR TITLE
Run GUI directly headless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         libgtk-3-0 libnss3 libxss1 libatk1.0-0 \
-        libxkbcommon0 libdrm2 libasound2 xvfb xauth \
+        libxkbcommon0 libdrm2 libasound2 \
         libgbm1 libnotify4 && \
     rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Two further environment variables control the configuration written to
 
 The entrypoint script rewrites `config.json` at startup using these values.
 
-The container installs `xvfb` and `xauth` and runs the GUI via `xvfb-run` so it
-works even without a graphical interface.
+The container runs the GUI directly in headless mode, so no virtual display is
+required.
 
 ## Logs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,6 @@ cat > "$CONFIG_FILE" <<EOF
 }
 EOF
 
-# Run the GUI in a headless X window
+# Run the GUI directly in headless mode
 exec > >(tee -a "$APP_HOME/gui.log") 2>&1
-exec xvfb-run --auto-servernum --server-num=1 "$APP_HOME/gui-linux" "$@"
+exec "$APP_HOME/gui-linux" "$@"


### PR DESCRIPTION
## Summary
- run the GUI executable directly instead of using `xvfb-run`
- remove unused xvfb/xauth packages from Dockerfile
- update README to reflect the simpler headless setup

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6862845d6ae8832a87617dd06e0f69cd